### PR TITLE
Enhance Path Resolution for HLSL File Includes

### DIFF
--- a/Editor/PackagePathResolver.cs
+++ b/Editor/PackagePathResolver.cs
@@ -1,0 +1,33 @@
+﻿namespace GfxQA.ShaderVariantTool
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+
+    using UnityEditor.PackageManager;
+
+    using UnityEngine;
+
+    public static class PackagePathResolver
+    {
+        public static string GetPackageAbsolutePath(string packageName)
+        {
+            Type packageInfoType = typeof(PackageInfo);
+            MethodInfo method = packageInfoType.GetMethod("GetAllRegisteredPackages", BindingFlags.NonPublic | BindingFlags.Static);
+            if (method != null)
+            {
+                var packages = (PackageInfo[])method.Invoke(null, null);
+                foreach (PackageInfo package in packages)
+                {
+                    if (package.name == packageName)
+                    {
+                        return Path.GetFullPath(package.resolvedPath);
+                    }
+                }
+            }
+
+            Debug.LogWarning($"Package '{packageName}' not found.");
+            return null;
+        }
+    }
+}

--- a/Editor/PackagePathResolver.cs.meta
+++ b/Editor/PackagePathResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b6fa60b27ef455bb4ebdca0aa043213
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ShaderVariantTool_Data.cs
+++ b/Editor/ShaderVariantTool_Data.cs
@@ -5,6 +5,7 @@ using UnityEngine.Rendering;
 using UnityEditor;
 using System.Linq;
 using System;
+using System.IO;
 using System.Text.RegularExpressions;
 
 namespace GfxQA.ShaderVariantTool
@@ -148,6 +149,7 @@ namespace GfxQA.ShaderVariantTool
                 var shader = Shader.Find(name);
                 var shaderData = ShaderUtil.GetShaderData(shader);
                 var subShader = shaderData.GetSubshader(0);
+                var shaderPath = AssetDatabase.GetAssetPath(shader);
                 for (int i = 0; i < subShader.PassCount; i++)
                 {
                     //Get source code
@@ -160,12 +162,13 @@ namespace GfxQA.ShaderVariantTool
                     //Read #include_with_pragmas lines as declare types are in seperate hlsl
                     string pattern = @"#include_with_pragmas\s""(.*)""";
                     MatchCollection matches = Regex.Matches(shaderCode, pattern);
+                    string shaderDirectoryPath = Path.GetDirectoryName(shaderPath);
                     List<Match> matchesList = matches.ToList();
                     foreach(Match m in matchesList)
                     {
                         //Read hlsl code and find the #pragma lines
                         string hlslPath = m.Groups[1].Value;
-                        string hlslCode = System.IO.File.ReadAllText(hlslPath);
+                        string hlslCode = ReadFromAnyPath(shaderDirectoryPath, hlslPath);
                         GetDirectPragmaKeywordType(hlslCode, ref keywordDeclareType);
                     }
                 }
@@ -176,6 +179,61 @@ namespace GfxQA.ShaderVariantTool
                     string keyword = item.shaderKeywordName;
                     item.shaderKeywordDeclareType = keywordDeclareType.FirstOrDefault(x => x.Key.Contains(keyword)).Value;
                 }
+            }
+        }
+
+        private string ReadFromAnyPath(string sourceDirectory, string path)
+        {
+            if (TryReadRelativePath(path, out string content))
+            {
+                return content;
+            }
+
+            if (TryReadAbsolutePath(path, out content))
+            {
+                return content;
+            }
+
+            if (TryReadUPMPackagePath(path, out content))
+            {
+                return content;
+            }
+
+            Debug.LogError($"ShaderVariantTool error. Included file {path} is not found.");
+            return null;
+
+            bool TryReadRelativePath(string filePath, out string contentRelativePath)
+            {
+                string fullPath = Path.Combine(sourceDirectory, filePath);
+                return TryReadAbsolutePath(fullPath, out contentRelativePath);
+            }
+
+            bool TryReadAbsolutePath(string filePath, out string contentAbsolutePath)
+            {
+                if (File.Exists(filePath))
+                {
+                    contentAbsolutePath = File.ReadAllText(filePath);
+                    return true;
+                }
+
+                contentAbsolutePath = null;
+                return false;
+            }
+
+            bool TryReadUPMPackagePath(string filePath, out string contentUPMPackage)
+            {
+                const string pattern = @"Packages\/(.*)\/(.*)";
+                MatchCollection matches = Regex.Matches(filePath, pattern);
+                if (matches.Count > 0)
+                {
+                    string packageName = matches[0].Groups[1].Value;
+                    string packageRoot = PackagePathResolver.GetPackageAbsolutePath(packageName);
+                    string fullPath = Path.Combine(packageRoot, matches[0].Groups[2].Value);
+                    return TryReadAbsolutePath(fullPath, out contentUPMPackage);
+                }
+
+                contentUPMPackage = null;
+                return false;
             }
         }
 


### PR DESCRIPTION
This pull request addresses an issue where `File.ReadAllText` in `SetKeywordDeclareType` throws a `FileNotFoundException` when handling `.hlsl` files that are not specified with an absolute path. This is particularly important for users who utilize relative paths or a special path which consists of `Packages` and the package name (e.g. `Package/com.unity.render-pipelines.universal`) to include files in Unity Package Manager.

To enhance flexibility, `SetKeywordDeclareType` should accommodate file includes specified by absolute paths, relative paths, and package paths.

## Changes

- **PackagePathResolver**: Added a utility class to retrieve the absolute path for a specified package name.

- **ReadFromAnyPath**: Updated the file reading logic to:
  1. Initially attempt to read the included file using the relative path.
  2. Fallback to reading the file using its absolute path if the relative path fails.
  3. As a final resort, extract the package name and resolve its absolute path using `PackagePathResolver`, then attempt to read the file.